### PR TITLE
Solving the Issue #47, Zero candidate string length issue.

### DIFF
--- a/bert_score/utils.py
+++ b/bert_score/utils.py
@@ -76,13 +76,18 @@ model2layers = {
 
 def sent_encode(tokenizer, sent):
     "Encoding as sentence based on the tokenizer"
+    if (sent.strip() == ""):
+        # print("sent is empty")
+        snt = " "
+    else:
+        snt = sent.strip()
     if isinstance(tokenizer, GPT2Tokenizer):
         # for RoBERTa and GPT-2
-        return tokenizer.encode(sent.strip(), add_special_tokens=True,
+        return tokenizer.encode(snt, add_special_tokens=True,
                                 add_prefix_space=True,
                                 max_length=tokenizer.max_len)
     else:
-        return tokenizer.encode(sent.strip(), add_special_tokens=True,
+        return tokenizer.encode(snt, add_special_tokens=True,
                                 max_length=tokenizer.max_len)
 
 


### PR DESCRIPTION
#47 Issue, that I raised, it can be solved this way. The problem was that if the candidate string is of zero length, then the tokenizer would give an error saying that string index if out of range, because index 0 of the string does not have anything since the string is empty. So instead, I just added a space so that the string is not empty. Now the tokenizer does not give error.