### PR TITLE
Update score.py

### DIFF
--- a/bert_score/score.py
+++ b/bert_score/score.py
@@ -104,7 +104,8 @@ def score(
         tokenizer = AutoTokenizer.from_pretrained(model_type)
 
     model = get_model(model_type, num_layers, all_layers)
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
     model.to(device)
 
     if not idf:


### PR DESCRIPTION
I experienced CUDA out of memory issues when using BERT-score in the validation step, the reason being that there was not enough GPU memory available for loading the BERT-multilingual pretrained model during validation. Since we only use the embeddings of the pretrained model in eval() mode for score calculation it would do no harm in assigning device to 'cpu'. 