### PR TITLE
Removing model_types from utils.py

### DIFF
--- a/bert_score/__init__.py
+++ b/bert_score/__init__.py
@@ -1,4 +1,3 @@
 __version__ = "0.3.3"
-from .utils import *
 from .score import *
 from .scorer import *

--- a/bert_score/score.py
+++ b/bert_score/score.py
@@ -16,7 +16,6 @@ from .utils import (
     get_idf_dict,
     bert_cos_score_idf,
     get_bert_embedding,
-    model_types,
     lang2model,
     model2layers,
     get_hash,

--- a/bert_score/scorer.py
+++ b/bert_score/scorer.py
@@ -17,7 +17,6 @@ from .utils import (
     get_idf_dict,
     bert_cos_score_idf,
     get_bert_embedding,
-    model_types,
     lang2model,
     model2layers,
     get_hash,

--- a/bert_score/utils.py
+++ b/bert_score/utils.py
@@ -15,7 +15,7 @@ from transformers import AutoModel, GPT2Tokenizer
 from . import __version__
 from transformers import __version__ as trans_version
 
-__all__ = ["model_types"]
+__all__ = []
 
 SCIBERT_URL_DICT = {
     "scibert-scivocab-uncased": "https://s3-us-west-2.amazonaws.com/ai2-s2-research/scibert/pytorch_models/scibert_scivocab_uncased.tar",  # recommend by the SciBERT authors
@@ -24,13 +24,6 @@ SCIBERT_URL_DICT = {
     "scibert-basevocab-cased": "https://s3-us-west-2.amazonaws.com/ai2-s2-research/scibert/pytorch_models/scibert_basevocab_cased.tar",
 }
 
-model_types = (
-    list(BertConfig.pretrained_config_archive_map.keys())
-    + list(XLNetConfig.pretrained_config_archive_map.keys())
-    + list(RobertaConfig.pretrained_config_archive_map.keys())
-    + list(XLMConfig.pretrained_config_archive_map.keys())
-    + list(SCIBERT_URL_DICT.keys())
-)
 
 lang2model = defaultdict(lambda: "bert-base-multilingual-cased")
 lang2model.update(


### PR DESCRIPTION
Hey, looks like the library is currently broken when installed with the latest versions of everything.

Since the latest release in transformers (more specifically, since this commit https://github.com/huggingface/transformers/commit/d4c2cb402d6674211726fd5f4803d1090664e438) the config maps (pretrained_config_archive_map) do not exist.

This means that bertscore right now fails when used with the latest version of transformers, which it will pull when installing locally. 
 
e.g, when running the unittests:
======================================================================
ERROR: bert_score (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: bert_score
Traceback (most recent call last):
  File "/home/ec2-user/anaconda3/lib/python3.6/unittest/loader.py", line 462, in _find_test_path
    package = self._get_module_from_name(name)
  File "/home/ec2-user/anaconda3/lib/python3.6/unittest/loader.py", line 369, in _get_module_from_name
    __import__(name)
  File "/home/ec2-user/useful_code/bert_score/bert_score/__init__.py", line 2, in <module>
    from .utils import *
  File "/home/ec2-user/useful_code/bert_score/bert_score/utils.py", line 32, in <module>
    + list(SCIBERT_URL_DICT.keys())
AttributeError: type object 'BertConfig' has no attribute 'pretrained_config_archive_map'

Solution
======================================================================
SInce this attribute is no longer being used anywhere, the easy fix here is to remove the map from utils.py as everything is migrated to AutoTokenizer anyway.

