### PR TITLE
Embed longest sentences first to tune batch size

### DIFF
--- a/bert_score/utils.py
+++ b/bert_score/utils.py
@@ -368,7 +368,7 @@ def bert_cos_score_idf(
     preds = []
 
     def dedup_and_sort(l):
-        return sorted(list(set(l)), key=lambda x: len(x.split(" ")))
+        return sorted(list(set(l)), key=lambda x: len(x.split(" ")), reverse=True)
 
     sentences = dedup_and_sort(refs + hyps)
     embs = []


### PR DESCRIPTION
Just a suggestion, but it might help to process the longest texts first, in order to catch OOMs at the beginning of BERT-scoring, instead of at the end. This would help to quickly tune batch size to the largest possible value given your current hardware.

The code is otherwise pretty optimized!