### PR TITLE
Add truncation argument to remove truncation warnings

### DIFF
--- a/bert_score/utils.py
+++ b/bert_score/utils.py
@@ -104,9 +104,9 @@ def sent_encode(tokenizer, sent):
         return tokenizer.build_inputs_with_special_tokens([])
     elif isinstance(tokenizer, GPT2Tokenizer):
         # for RoBERTa and GPT-2
-        return tokenizer.encode(sent, add_special_tokens=True, add_prefix_space=True, max_length=tokenizer.max_len)
+        return tokenizer.encode(sent, add_special_tokens=True, add_prefix_space=True, max_length=tokenizer.max_len, truncation=True)
     else:
-        return tokenizer.encode(sent, add_special_tokens=True, max_length=tokenizer.max_len)
+        return tokenizer.encode(sent, add_special_tokens=True, max_length=tokenizer.max_len, truncation=True)
 
 
 def get_model(model_type, num_layers, all_layers=None):


### PR DESCRIPTION
Like issue found [here](https://github.com/huggingface/transformers/issues/5397), `transformers` v3.0.0  has an updated tokenizer API where if you supply `max_length` argument, you must also supply `truncation=(True|False)` argument to let the tokenizer know you want truncation to happen. If `truncation` argument is not set, warnings are generated.