### PR TITLE
Optimizing bert_cos_score_idf

### DIFF
--- a/bert_score/utils.py
+++ b/bert_score/utils.py
@@ -419,16 +419,15 @@ def bert_cos_score_idf(
         return emb_pad, pad_mask, idf_pad
 
     device = next(model.parameters()).device
-    matching_batch_size = batch_size * 2
-    iter_range = range(0, len(refs), matching_batch_size)
+    iter_range = range(0, len(refs), batch_size)
     if verbose:
         print("computing greedy matching.")
         iter_range = tqdm(iter_range)
 
     with torch.no_grad():
         for batch_start in iter_range:
-            batch_refs = refs[batch_start : batch_start + matching_batch_size]
-            batch_hyps = hyps[batch_start : batch_start + matching_batch_size]
+            batch_refs = refs[batch_start : batch_start + batch_size]
+            batch_hyps = hyps[batch_start : batch_start + batch_size]
             ref_stats = pad_batch_stats(batch_refs, stats_dict, device)
             hyp_stats = pad_batch_stats(batch_hyps, stats_dict, device)
 


### PR DESCRIPTION
1) Pad BERT embeddings on GPU instead of CPU. Padding on CPU is the bottleneck in computing the greedy matching, so padding on GPU speeds up the matching by ~3x for me. Moving tensors to GPU then becomes the bottleneck, but it also takes ~2x less time to move pre-padding tensors to GPU, I think since you don't have to move a bunch of padding numbers. So overall I get a ~6x speed up on the sequences I'm evaluating
2) Using `torch.no_grad()` when computing greedy matching to save memory. I was able to increase the batch size for greedy matching by 2x after doing this. I'm not sure if increasing the batch size here will cause OOMs for others though, so it might be worth someone else checking/trying it out (or just removing the batch size increase).

Edit: I was finding some OOMs with the batch size increase, so I removed that