### PR TITLE
[BUG_FIX] RobertaTokenizerFast object has no attributes max_len

### DIFF
--- a/bert_score/utils.py
+++ b/bert_score/utils.py
@@ -109,17 +109,20 @@ def sent_encode(tokenizer, sent):
 
         if LooseVersion(transformers.__version__) >= LooseVersion("3.0.0"):
             return tokenizer.encode(
-                sent, add_special_tokens=True, add_prefix_space=True, max_length=tokenizer.max_len, truncation=True
+                sent, add_special_tokens=True, add_prefix_space=True, max_length=tokenizer.model_max_length,
+                truncation=True
             )
         else:
-            return tokenizer.encode(sent, add_special_tokens=True, add_prefix_space=True, max_length=tokenizer.max_len)
+            return tokenizer.encode(sent, add_special_tokens=True, add_prefix_space=True,
+                                    max_length=tokenizer.model_max_length)
     else:
         import transformers
 
         if LooseVersion(transformers.__version__) >= LooseVersion("3.0.0"):
-            return tokenizer.encode(sent, add_special_tokens=True, max_length=tokenizer.max_len, truncation=True)
+            return tokenizer.encode(sent, add_special_tokens=True, max_length=tokenizer.model_max_length,
+                                    truncation=True)
         else:
-            return tokenizer.encode(sent, add_special_tokens=True, max_length=tokenizer.max_len)
+            return tokenizer.encode(sent, add_special_tokens=True, max_length=tokenizer.model_max_length)
 
 
 def get_model(model_type, num_layers, all_layers=None):


### PR DESCRIPTION
Quick fix for the transfomers [update V4.0.0](https://github.com/huggingface/transformers/releases/tag/v4.0.0)

```
Regarding the tokenizer classes:

The tokenizer attribute max_len becomes model_max_length.
```
