### PR TITLE
Fixing issue when working directory is a path with spaces in it

### DIFF
--- a/bert_score/utils.py
+++ b/bert_score/utils.py
@@ -478,7 +478,7 @@ def cache_scibert(model_type, cache_folder="~/.cache/torch/transformers"):
         return model_type
 
     underscore_model_type = model_type.replace("-", "_")
-    cache_folder = os.path.abspath(cache_folder)
+    cache_folder = os.path.abspath(os.path.expanduser(cache_folder))
     filename = os.path.join(cache_folder, underscore_model_type)
 
     # download SciBERT models

--- a/tests/test_score_function.py
+++ b/tests/test_score_function.py
@@ -147,6 +147,26 @@ class TestScore(unittest.TestCase):
             cands, refs, batch_size=3, return_hash=False, lang="en", rescale_with_baseline=True
         )
 
+    def test_score_en_sci(self):
+        (P, R, F), hash_code = bert_score.score(
+            cands, refs, lang='en-sci', return_hash=True
+        )
+
+        self.assertTrue(torch.is_tensor(P))
+        self.assertTrue(torch.is_tensor(R))
+        self.assertTrue(torch.is_tensor(F))
+        self.assertEqual(
+            hash_code, f"scibert-scivocab-uncased_L8_no-idf_version={bert_score.__version__}(hug_trans={ht_version})"
+        )
+        self.assertTrue(
+            (P - torch.tensor([0.9785506725, 0.9363335371, 0.8104354143])).abs_().max() < EPS
+        )
+        self.assertTrue(
+            (R - torch.tensor([0.9785507321, 0.9109522700, 0.7933146954])).abs_().max() < EPS
+        )
+        self.assertTrue(
+            (F - torch.tensor([0.9785507321, 0.9234685898, 0.8017836809])).abs_().max() < EPS
+        )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I discovered that when the current working directory includes a path with spaces in it, calling `score(...lang='en-sci'...)` results in an error. I'm running macOS 10.14.6 with Python 3.8.5 and have only tested this patch on that environment.

Running this example line from `~/dir with spaces/` results in the following:

```python
P, R, F1 = score(cands, refs, lang="en-sci", verbose=True)
```

```python
mkdir -p /Users/magiclantern/dir with spaces/~/.cache/torch/transformers; cd /Users/magiclantern/dir with spaces/~/.cache/torch/transformers;wget https://s3-us-west-2.amazonaws.com/ai2-s2-research/scibert/pytorch_models/scibert_scivocab_uncased.tar; tar -xvf scibert_scivocab_uncased.tar;rm -f scibert_scivocab_uncased.tar ; cd scibert_scivocab_uncased; tar -zxvf weights.tar.gz; mv weights/* .;rm -f weights.tar.gz; rmdir weights; mv bert_config.json config.json;
downloading scibert-scivocab-uncased model

---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-10-5a654ca28163> in <module>
----> 1 P, R, F1 = score(preds, refs, lang="en-sci", verbose=True)

/opt/anaconda3/envs/nlp/lib/python3.8/site-packages/bert_score/score.py in score(cands, refs, model_type, num_layers, verbose, idf, device, batch_size, nthreads, all_layers, lang, return_hash, rescale_with_baseline, baseline_path)
    101         num_layers = model2layers[model_type]
    102 
--> 103     tokenizer = get_tokenizer(model_type)
    104     model = get_model(model_type, num_layers, all_layers)
    105     if device is None:

/opt/anaconda3/envs/nlp/lib/python3.8/site-packages/bert_score/utils.py in get_tokenizer(model_type)
    183 def get_tokenizer(model_type):
    184     if model_type.startswith("scibert"):
--> 185         model_type = cache_scibert(model_type)
    186 
    187     if LooseVersion(trans_version) >= LooseVersion("4.0.0"):

/opt/anaconda3/envs/nlp/lib/python3.8/site-packages/bert_score/utils.py in cache_scibert(model_type, cache_folder)
    497     json_file = os.path.join(filename, "special_tokens_map.json")
    498     if not os.path.exists(json_file):
--> 499         with open(json_file, "w") as f:
    500             print(
    501                 '{"unk_token": "[UNK]", "sep_token": "[SEP]", "pad_token": "[PAD]", "cls_token": "[CLS]", "mask_token": "[MASK]"}',

FileNotFoundError: [Errno 2] No such file or directory: '/Users/magiclantern/dir with spaces/~/.cache/torch/transformers/scibert_scivocab_uncased/special_tokens_map.json'
```

This pull request modifies one line of code to resolve the path issue.

Additionally, I noticed that there are no unit tests covering the `en-sci` aka scibert functionality, so I added a very simple test to help catch potential issues in the future with the code that is geared toward scibert.