### PR TITLE
Fix bug which causes `score` method to ignore `BERTScorer` object's `batch_size` attribute

### DIFF
--- a/bert_score/scorer.py
+++ b/bert_score/scorer.py
@@ -43,7 +43,6 @@ class BERTScorer:
                       `model_type` or `lang`
             - :param: `num_layers` (int): the layer of representation to use.
                       default using the number of layer tuned on WMT16 correlation data
-            - :param: `verbose` (bool): turn on intermediate status update
             - :param: `idf` (bool): a booling to specify whether to use idf or not (this should be True even if `idf_sents` is given)
             - :param: `idf_sents` (List of str): list of sentences used to compute the idf weights
             - :param: `device` (str): on which the contextual embedding model will be allocated on.
@@ -53,7 +52,6 @@ class BERTScorer:
             - :param: `lang` (str): language of the sentences; has to specify
                       at least one of `model_type` or `lang`. `lang` needs to be
                       specified when `rescale_with_baseline` is True.
-            - :param: `return_hash` (bool): return hash code of the setting
             - :param: `rescale_with_baseline` (bool): rescale bertscore with pre-computed baseline
             - :param: `baseline_path` (str): customized baseline file
             - :param: `use_fast_tokenizer` (bool): `use_fast` parameter passed to HF tokenizer

--- a/bert_score/scorer.py
+++ b/bert_score/scorer.py
@@ -1,6 +1,5 @@
 import os
-import pathlib
-import sys
+
 import time
 import warnings
 from collections import defaultdict
@@ -179,7 +178,7 @@ class BERTScorer:
 
         self._idf_dict = get_idf_dict(sents, self._tokenizer, nthreads=self.nthreads)
 
-    def score(self, cands, refs, verbose=False, batch_size=64, return_hash=False):
+    def score(self, cands, refs, verbose=False, batch_size=None, return_hash=False):
         """
         Args:
             - :param: `cands` (list of str): candidate sentences
@@ -216,6 +215,9 @@ class BERTScorer:
             idf_dict = defaultdict(lambda: 1.0)
             idf_dict[self._tokenizer.sep_token_id] = 0
             idf_dict[self._tokenizer.cls_token_id] = 0
+
+        if batch_size is None:
+            batch_size = self.batch_size
 
         all_preds = bert_cos_score_idf(
             self._model,


### PR DESCRIPTION
There is a bug in the `score()` method's code: A `batch_size` attribute can be specified for the `BERTScorer` object, but this setting is ignored by the `score()` method currently. In fact this attribute of the `BERTScorer` object has no effect at all.

The proposed fix is that if a `batch_size` argument is not specified explicitly for the `score()` method, then the value of the `BERTScorer` object's `batch_size` attribute is used for calculating the embeddings.

Another possibility would be to remove the `batch_size` attribute and, along with it, the `batch_size` parameter of the `BERTScorer` class and its initializer method respectively, just like it was apparently done for `verbose` and `return_hash` earlier (I fixed the docstrings and removed these outdated parameters), but this would modify the interface of the class and thus break backward compatibility, so I'd rather not do that. I believe it's better to fix the bug instead.

Note: This bug is no joke. I just lost some 3 or 4 hours of time because of it, trying to understand why BERTScore keeps running out of GPU RAM despite my having set batch size to 1, before it occurred to me that I should check if there's maybe some bug in the code.