### PR TITLE
fix: cap model_max_length sentinel value to prevent OverflowError in …

### DIFF
--- a/bert_score/utils.py
+++ b/bert_score/utils.py
@@ -188,6 +188,8 @@ model2layers = {
 def sent_encode(tokenizer, sent):
     "Encoding as sentence based on the tokenizer"
     sent = sent.strip()
+    if tokenizer.model_max_length > 1e30:
+        tokenizer.model_max_length = 512
     if sent == "":
         return tokenizer.build_inputs_with_special_tokens([])
     elif isinstance(tokenizer, GPT2Tokenizer) or isinstance(tokenizer, RobertaTokenizer):


### PR DESCRIPTION
## Problem
When using `bert_score` with models that don't explicitly define `model_max_length` 
(e.g. DeBERTa, DistilBERT), HuggingFace assigns a sentinel value 
(`VERY_LARGE_INTEGER` ~ 1e30) as the default. This gets passed to the Rust 
tokenizers backend and causes an `OverflowError` since it exceeds int32 bounds.

## Fix
Cap `model_max_length` to 512 in `sent_encode()` in `utils.py` before it 
reaches the Rust backend.

## Related
- Fixes #205 
- HuggingFace evaluate issue: huggingface/evaluate#739
- Abandoned evaluate PR: huggingface/evaluate#756 (fix belongs here, not in evaluate)